### PR TITLE
Add data-driven fantasy RPG text adventure

### DIFF
--- a/data/rpg/classes.json
+++ b/data/rpg/classes.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "guardian",
+    "name": "Guardian of Aegis",
+    "description": "Stalwart defenders who weather the fiercest blows and retaliate with crushing force.",
+    "primaryStat": "strength",
+    "baseStats": {
+      "health": 140,
+      "mana": 50,
+      "strength": 12,
+      "agility": 6,
+      "intellect": 4
+    },
+    "statGrowth": {
+      "health": 22,
+      "mana": 6,
+      "strength": 3,
+      "agility": 1,
+      "intellect": 1
+    },
+    "abilities": [
+      {
+        "id": "shield_slam",
+        "name": "Shield Slam",
+        "type": "damage",
+        "resourceCost": 10,
+        "stat": "strength",
+        "multiplier": 1.5,
+        "flatBonus": 8,
+        "description": "A brutal bash that scales with Strength."
+      },
+      {
+        "id": "fortifying_roar",
+        "name": "Fortifying Roar",
+        "type": "heal",
+        "resourceCost": 15,
+        "stat": "strength",
+        "multiplier": 1.1,
+        "flatBonus": 10,
+        "description": "Rally your spirit to regain vitality before the next clash."
+      }
+    ],
+    "startingItems": [
+      "steel_bastard_sword",
+      "sturdy_shield"
+    ]
+  },
+  {
+    "id": "spellweaver",
+    "name": "Spellweaver",
+    "description": "Scholars of arcane energies who bend raw mana into devastating spells and protective wards.",
+    "primaryStat": "intellect",
+    "baseStats": {
+      "health": 100,
+      "mana": 120,
+      "strength": 4,
+      "agility": 6,
+      "intellect": 14
+    },
+    "statGrowth": {
+      "health": 14,
+      "mana": 20,
+      "strength": 1,
+      "agility": 2,
+      "intellect": 4
+    },
+    "abilities": [
+      {
+        "id": "arcane_bolt",
+        "name": "Arcane Bolt",
+        "type": "damage",
+        "resourceCost": 12,
+        "stat": "intellect",
+        "multiplier": 1.7,
+        "flatBonus": 5,
+        "description": "Unleash condensed arcane power at your foe."
+      },
+      {
+        "id": "mystic_barrier",
+        "name": "Mystic Barrier",
+        "type": "heal",
+        "resourceCost": 18,
+        "stat": "intellect",
+        "multiplier": 1.4,
+        "flatBonus": 12,
+        "description": "Transmute mana into a ward that mends your wounds."
+      }
+    ],
+    "startingItems": [
+      "apprentice_focus",
+      "spellthread_robe"
+    ]
+  },
+  {
+    "id": "shadowstalker",
+    "name": "Shadowstalker",
+    "description": "Masters of stealth and precision strikes who dance between the shadows and their prey.",
+    "primaryStat": "agility",
+    "baseStats": {
+      "health": 115,
+      "mana": 70,
+      "strength": 8,
+      "agility": 14,
+      "intellect": 5
+    },
+    "statGrowth": {
+      "health": 18,
+      "mana": 8,
+      "strength": 2,
+      "agility": 4,
+      "intellect": 1
+    },
+    "abilities": [
+      {
+        "id": "twin_fang",
+        "name": "Twin Fang",
+        "type": "damage",
+        "resourceCost": 8,
+        "stat": "agility",
+        "multiplier": 1.6,
+        "flatBonus": 6,
+        "description": "Strike twice in a blur, each cut deepened by Agility."
+      },
+      {
+        "id": "smoke_recovery",
+        "name": "Smoke Recovery",
+        "type": "heal",
+        "resourceCost": 12,
+        "stat": "agility",
+        "multiplier": 1.2,
+        "flatBonus": 9,
+        "description": "Vanish in smoke to bind your wounds before emerging."
+      }
+    ],
+    "startingItems": [
+      "twilight_twinblades",
+      "shadowguard_cloak"
+    ]
+  }
+]

--- a/data/rpg/dungeons.json
+++ b/data/rpg/dungeons.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "heart_of_the_grove",
+    "name": "Heart of the Grove",
+    "zoneId": "verdant_frontier",
+    "description": "Delve into the ancient heartwood and calm the fury of the forest guardian.",
+    "recommendedLevel": 2,
+    "encounters": ["forest_wolf", "thornlash_satyr", "runebloom_sprite"],
+    "boss": "ancient_treant",
+    "rewards": ["ancient_bark_amulet"]
+  },
+  {
+    "id": "smoldering_core",
+    "name": "Smoldering Core",
+    "zoneId": "ashen_peaks",
+    "description": "Descend into the volcano's heart where molten elementals plot a fiery rebirth.",
+    "recommendedLevel": 4,
+    "encounters": ["ember_imp", "ashen_elemental", "slag_titan"],
+    "boss": "magma_lord",
+    "rewards": ["emberforged_plating"]
+  },
+  {
+    "id": "citadel_of_mists",
+    "name": "Citadel of Mists",
+    "zoneId": "mists_end",
+    "description": "Navigate the drowned battlements to confront the sovereign that commands the tides.",
+    "recommendedLevel": 6,
+    "encounters": ["mist_wraith", "drowned_corsair", "veilwing_matriarch"],
+    "boss": "mist_sovereign",
+    "rewards": ["siren_song_shell"]
+  }
+]

--- a/data/rpg/enemies.json
+++ b/data/rpg/enemies.json
@@ -1,0 +1,154 @@
+[
+  {
+    "id": "forest_wolf",
+    "name": "Forest Wolf",
+    "level": 1,
+    "health": 38,
+    "damage": { "min": 4, "max": 8 },
+    "xp": 24,
+    "habitats": ["verdant_frontier"],
+    "loot": [
+      { "itemId": "wolf_pelt", "chance": 0.6 },
+      { "itemId": "sunburst_bloom", "chance": 0.25 }
+    ]
+  },
+  {
+    "id": "thornlash_satyr",
+    "name": "Thornlash Satyr",
+    "level": 2,
+    "health": 52,
+    "damage": { "min": 6, "max": 11 },
+    "xp": 40,
+    "habitats": ["verdant_frontier"],
+    "loot": [
+      { "itemId": "luminous_cap", "chance": 0.45 },
+      { "itemId": "wolf_pelt", "chance": 0.35 }
+    ]
+  },
+  {
+    "id": "runebloom_sprite",
+    "name": "Runebloom Sprite",
+    "level": 3,
+    "health": 44,
+    "damage": { "min": 5, "max": 9 },
+    "xp": 46,
+    "habitats": ["verdant_frontier"],
+    "loot": [
+      { "itemId": "sunburst_bloom", "chance": 0.65 },
+      { "itemId": "lorekeepers_charm", "chance": 0.1 }
+    ]
+  },
+  {
+    "id": "ember_imp",
+    "name": "Ember Imp",
+    "level": 3,
+    "health": 58,
+    "damage": { "min": 7, "max": 13 },
+    "xp": 52,
+    "habitats": ["ashen_peaks"],
+    "loot": [
+      { "itemId": "smoldering_cinder", "chance": 0.7 }
+    ]
+  },
+  {
+    "id": "ashen_elemental",
+    "name": "Ashen Elemental",
+    "level": 4,
+    "health": 72,
+    "damage": { "min": 9, "max": 16 },
+    "xp": 72,
+    "habitats": ["ashen_peaks"],
+    "loot": [
+      { "itemId": "molten_ore", "chance": 0.5 },
+      { "itemId": "smoldering_cinder", "chance": 0.4 }
+    ]
+  },
+  {
+    "id": "slag_titan",
+    "name": "Slag Titan",
+    "level": 5,
+    "health": 110,
+    "damage": { "min": 12, "max": 20 },
+    "xp": 110,
+    "habitats": ["ashen_peaks"],
+    "loot": [
+      { "itemId": "molten_ore", "chance": 0.65 },
+      { "itemId": "emberforged_plating", "chance": 0.08 }
+    ]
+  },
+  {
+    "id": "mist_wraith",
+    "name": "Mist Wraith",
+    "level": 4,
+    "health": 70,
+    "damage": { "min": 8, "max": 15 },
+    "xp": 68,
+    "habitats": ["mists_end"],
+    "loot": [
+      { "itemId": "veilstone_shard", "chance": 0.3 },
+      { "itemId": "scrying_sigil", "chance": 0.05 }
+    ]
+  },
+  {
+    "id": "drowned_corsair",
+    "name": "Drowned Corsair",
+    "level": 5,
+    "health": 90,
+    "damage": { "min": 11, "max": 19 },
+    "xp": 95,
+    "habitats": ["mists_end"],
+    "loot": [
+      { "itemId": "veilstone_shard", "chance": 0.4 },
+      { "itemId": "wolf_pelt", "chance": 0.15 }
+    ]
+  },
+  {
+    "id": "veilwing_matriarch",
+    "name": "Veilwing Matriarch",
+    "level": 6,
+    "health": 120,
+    "damage": { "min": 13, "max": 22 },
+    "xp": 132,
+    "habitats": ["mists_end"],
+    "loot": [
+      { "itemId": "veilstone_shard", "chance": 0.55 },
+      { "itemId": "siren_song_shell", "chance": 0.12 }
+    ]
+  },
+  {
+    "id": "ancient_treant",
+    "name": "Ancient Treant",
+    "level": 7,
+    "health": 180,
+    "damage": { "min": 15, "max": 24 },
+    "xp": 200,
+    "habitats": ["heart_of_the_grove"],
+    "loot": [
+      { "itemId": "ancient_bark_amulet", "chance": 0.9 }
+    ]
+  },
+  {
+    "id": "magma_lord",
+    "name": "Magma Lord",
+    "level": 8,
+    "health": 210,
+    "damage": { "min": 18, "max": 28 },
+    "xp": 240,
+    "habitats": ["smoldering_core"],
+    "loot": [
+      { "itemId": "emberforged_plating", "chance": 0.85 }
+    ]
+  },
+  {
+    "id": "mist_sovereign",
+    "name": "Mist Sovereign",
+    "level": 9,
+    "health": 240,
+    "damage": { "min": 20, "max": 32 },
+    "xp": 280,
+    "habitats": ["citadel_of_mists"],
+    "loot": [
+      { "itemId": "siren_song_shell", "chance": 0.88 }
+    ]
+  }
+]

--- a/data/rpg/items.json
+++ b/data/rpg/items.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "steel_bastard_sword",
+    "name": "Steel Bastard Sword",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "description": "A balanced blade favored by defenders who must strike back while holding the line.",
+    "value": 45,
+    "effects": {
+      "strengthBonus": 2
+    }
+  },
+  {
+    "id": "sturdy_shield",
+    "name": "Sturdy Shield",
+    "type": "armor",
+    "rarity": "common",
+    "description": "Solid oak reinforced with iron bands. Reliable and heavy.",
+    "value": 30,
+    "effects": {
+      "healthBonus": 15
+    }
+  },
+  {
+    "id": "apprentice_focus",
+    "name": "Apprentice's Focus",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "description": "A crystal focus etched with beginner incantations that steady the mind.",
+    "value": 38,
+    "effects": {
+      "intellectBonus": 3
+    }
+  },
+  {
+    "id": "spellthread_robe",
+    "name": "Spellthread Robe",
+    "type": "armor",
+    "rarity": "common",
+    "description": "Robes woven with silvered thread that hum softly with stored mana.",
+    "value": 28,
+    "effects": {
+      "manaBonus": 20
+    }
+  },
+  {
+    "id": "twilight_twinblades",
+    "name": "Twilight Twinblades",
+    "type": "weapon",
+    "rarity": "rare",
+    "description": "Paired daggers that drink in light and release it as lethal momentum.",
+    "value": 52,
+    "effects": {
+      "agilityBonus": 3
+    }
+  },
+  {
+    "id": "shadowguard_cloak",
+    "name": "Shadowguard Cloak",
+    "type": "armor",
+    "rarity": "uncommon",
+    "description": "A cloak treated with whispering dyes that blur the wearer's outline.",
+    "value": 34,
+    "effects": {
+      "evasionBonus": 5
+    }
+  },
+  {
+    "id": "wolf_pelt",
+    "name": "Wolf Pelt",
+    "type": "crafting",
+    "rarity": "common",
+    "description": "A thick pelt from a forest wolf, still warm to the touch.",
+    "value": 8
+  },
+  {
+    "id": "sunburst_bloom",
+    "name": "Sunburst Bloom",
+    "type": "reagent",
+    "rarity": "uncommon",
+    "description": "A radiant flower that stores sunlight in its petals.",
+    "value": 16
+  },
+  {
+    "id": "luminous_cap",
+    "name": "Luminous Cap",
+    "type": "reagent",
+    "rarity": "common",
+    "description": "A glowcap mushroom used to brew restorative tonics.",
+    "value": 10
+  },
+  {
+    "id": "molten_ore",
+    "name": "Molten Ore",
+    "type": "crafting",
+    "rarity": "uncommon",
+    "description": "Chunks of ore that radiate residual volcanic heat.",
+    "value": 22
+  },
+  {
+    "id": "smoldering_cinder",
+    "name": "Smoldering Cinder",
+    "type": "reagent",
+    "rarity": "common",
+    "description": "An ember that refuses to cool, coveted by fire-smiths.",
+    "value": 12
+  },
+  {
+    "id": "veilstone_shard",
+    "name": "Veilstone Shard",
+    "type": "crafting",
+    "rarity": "rare",
+    "description": "A crystalline fragment that resonates with the echo of the sea.",
+    "value": 35
+  },
+  {
+    "id": "ancient_bark_amulet",
+    "name": "Ancient Bark Amulet",
+    "type": "trinket",
+    "rarity": "rare",
+    "description": "A talisman carved from the Heartwood, blessing the wearer with endurance.",
+    "value": 60,
+    "effects": {
+      "healthBonus": 20
+    }
+  },
+  {
+    "id": "emberforged_plating",
+    "name": "Emberforged Plating",
+    "type": "trinket",
+    "rarity": "epic",
+    "description": "Plate segments quenched in dragonfire that harden under stress.",
+    "value": 80,
+    "effects": {
+      "strengthBonus": 3
+    }
+  },
+  {
+    "id": "siren_song_shell",
+    "name": "Siren Song Shell",
+    "type": "trinket",
+    "rarity": "epic",
+    "description": "A conch that hums with foresight, guiding spellcraft with gentle whispers.",
+    "value": 85,
+    "effects": {
+      "intellectBonus": 4
+    }
+  },
+  {
+    "id": "lorekeepers_charm",
+    "name": "Lorekeeper's Charm",
+    "type": "trinket",
+    "rarity": "uncommon",
+    "description": "Charm of polished amber that glows when secrets are near.",
+    "value": 28
+  },
+  {
+    "id": "tempered_bracelets",
+    "name": "Tempered Bracelets",
+    "type": "trinket",
+    "rarity": "uncommon",
+    "description": "Metalwork that stores latent heat, warming the wearer before a fight.",
+    "value": 32
+  },
+  {
+    "id": "scrying_sigil",
+    "name": "Scrying Sigil",
+    "type": "trinket",
+    "rarity": "rare",
+    "description": "An etched stone that pulses when danger approaches.",
+    "value": 48
+  }
+]

--- a/data/rpg/npcs.json
+++ b/data/rpg/npcs.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "elyra_moonwhisper",
+    "name": "Elyra Moonwhisper",
+    "zoneId": "verdant_frontier",
+    "role": "Lorekeeper",
+    "description": "A night elf scholar cataloguing the ever-shifting runes of the frontier.",
+    "dialogue": [
+      "Every leaf carries a chronicle. Listen, and the forest will speak.",
+      "Guardians once patrolled these woods. Their spirits still watch for worthy heirs.",
+      "If you seek peace, you must first soothe the hearts of the satyrs."
+    ],
+    "rewards": [
+      {
+        "itemId": "lorekeepers_charm",
+        "description": "Elyra presses a warm charm into your palm.",
+        "once": true
+      }
+    ],
+    "teachesProfessions": ["herbalism"]
+  },
+  {
+    "id": "talan_forgeborne",
+    "name": "Talan Forgeborn",
+    "zoneId": "ashen_peaks",
+    "role": "Battlesmith",
+    "description": "A dwarf whose forge sits perilously close to flowing magma.",
+    "dialogue": [
+      "Feel that tremor? The mountain's heart is restless tonight.",
+      "Bring me ore that still smokes and I'll temper you gear fit for heroes.",
+      "I've seen imps swarm like sparks. Keep your shield high and your courage higher."
+    ],
+    "rewards": [
+      {
+        "itemId": "tempered_bracelets",
+        "description": "Talan clasps heated bracelets around your wrists.",
+        "once": true
+      }
+    ],
+    "teachesProfessions": ["mining"]
+  },
+  {
+    "id": "seer_kaldra",
+    "name": "Seer Kaldra",
+    "zoneId": "mists_end",
+    "role": "Tide Seer",
+    "description": "An orc seer who reads the future in the ebb and flow of spectral tides.",
+    "dialogue": [
+      "The mists remember those who were lost—and those yet to fall.",
+      "Every tide carries whispers from realms beyond the veil.",
+      "Trust the rhythm of the waves. They warn before the Sovereign strikes."
+    ],
+    "rewards": [
+      {
+        "itemId": "scrying_sigil",
+        "description": "Kaldra inscribes a sigil on smooth stone and gifts it to you.",
+        "once": true
+      }
+    ],
+    "teachesProfessions": ["rune_scribing"]
+  }
+]

--- a/data/rpg/professions.json
+++ b/data/rpg/professions.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "herbalism",
+    "name": "Herbalism",
+    "description": "Study the flora of Azerai, harvesting potent herbs for salves and spell-inks.",
+    "gathering": [
+      {
+        "itemId": "sunburst_bloom",
+        "notes": "Key ingredient for radiant elixirs."
+      },
+      {
+        "itemId": "luminous_cap",
+        "notes": "Fungal spores perfect for restorative draughts."
+      }
+    ]
+  },
+  {
+    "id": "mining",
+    "name": "Mining",
+    "description": "Extract rare metals and minerals from the bones of the world.",
+    "gathering": [
+      {
+        "itemId": "molten_ore",
+        "notes": "Smelted into arms for the bravest champions."
+      },
+      {
+        "itemId": "smoldering_cinder",
+        "notes": "A common byproduct still prized by smiths."
+      }
+    ]
+  },
+  {
+    "id": "rune_scribing",
+    "name": "Rune Scribing",
+    "description": "Shape arcane scripts and sigils from crystalline remnants.",
+    "gathering": [
+      {
+        "itemId": "veilstone_shard",
+        "notes": "Channels the tides of magic into lasting enchantments."
+      }
+    ]
+  }
+]

--- a/data/rpg/zones.json
+++ b/data/rpg/zones.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "verdant_frontier",
+    "name": "Verdant Frontier",
+    "description": "Ancient woods bordering the capital, alive with whispering spirits and prowling beasts.",
+    "recommendedLevel": 1,
+    "enemies": ["forest_wolf", "thornlash_satyr", "runebloom_sprite"],
+    "npcs": ["elyra_moonwhisper"],
+    "dungeons": ["heart_of_the_grove"],
+    "gatherables": [
+      {
+        "professionId": "herbalism",
+        "itemId": "sunburst_bloom",
+        "minQuantity": 1,
+        "maxQuantity": 2
+      },
+      {
+        "professionId": "herbalism",
+        "itemId": "luminous_cap",
+        "minQuantity": 1,
+        "maxQuantity": 3
+      }
+    ],
+    "ambientLore": [
+      "A gentle breeze carries motes of emerald light between the boughs.",
+      "Distant drums echo—tribes of satyrs practicing their war songs.",
+      "Runes etched into bark flare briefly as you pass, recognizing your presence."
+    ]
+  },
+  {
+    "id": "ashen_peaks",
+    "name": "Ashen Peaks",
+    "description": "Volcanic highlands where rivers of magma carve paths through blackened stone.",
+    "recommendedLevel": 3,
+    "enemies": ["ember_imp", "ashen_elemental", "slag_titan"],
+    "npcs": ["talan_forgeborne"],
+    "dungeons": ["smoldering_core"],
+    "gatherables": [
+      {
+        "professionId": "mining",
+        "itemId": "molten_ore",
+        "minQuantity": 1,
+        "maxQuantity": 2
+      },
+      {
+        "professionId": "mining",
+        "itemId": "smoldering_cinder",
+        "minQuantity": 1,
+        "maxQuantity": 2
+      }
+    ],
+    "ambientLore": [
+      "Geysers of ash erupt in the distance, briefly obscuring the twin moons.",
+      "A river of lava pulses like a heartbeat, lighting the crags blood-red.",
+      "Smiths whisper of a dragon that once slept beneath these mountains."
+    ]
+  },
+  {
+    "id": "mists_end",
+    "name": "Mist's End",
+    "description": "A drowned coastline where spectral fog wraps shattered fortresses in silence.",
+    "recommendedLevel": 5,
+    "enemies": ["mist_wraith", "drowned_corsair", "veilwing_matriarch"],
+    "npcs": ["seer_kaldra"],
+    "dungeons": ["citadel_of_mists"],
+    "gatherables": [
+      {
+        "professionId": "rune_scribing",
+        "itemId": "veilstone_shard",
+        "minQuantity": 1,
+        "maxQuantity": 1
+      }
+    ],
+    "ambientLore": [
+      "Spectral bells toll from beneath the tide, beckoning sailors long gone.",
+      "The mist parts to reveal silhouettes of towers swallowed by the sea.",
+      "An otherworldly chorus echoes across the surf before fading into a hush."
+    ]
+  }
+]

--- a/rpg.html
+++ b/rpg.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Legends of Azerai</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="/scripts/header.js"></script>
+    <script defer src="scripts/rpg-game.js"></script>
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            if (typeof loadHeader === 'function') {
+                loadHeader('header-placeholder');
+            }
+        });
+    </script>
+
+    <section class="rpg-section">
+        <h1>Legends of Azerai</h1>
+        <p class="intro">A data-driven text adventure inspired by classic fantasy RPGs. Expand the world by editing the JSON files inside <code>data/rpg</code>.</p>
+
+        <div class="rpg-layout">
+            <div class="rpg-panel">
+                <div class="rpg-card" id="setup-card">
+                    <h2>Character Setup</h2>
+                    <label for="player-name">Hero Name</label>
+                    <input type="text" id="player-name" placeholder="Optional">
+
+                    <label for="class-select">Class</label>
+                    <select id="class-select"></select>
+                    <div id="class-description" class="info-block"></div>
+
+                    <fieldset>
+                        <legend>Professions (choose up to 2)</legend>
+                        <div id="profession-options"></div>
+                    </fieldset>
+
+                    <button id="start-button">Start Adventure</button>
+                    <div id="setup-feedback" class="info-block"></div>
+                </div>
+
+                <div class="rpg-card" id="player-card">
+                    <h2>Adventurer Sheet</h2>
+                    <div id="player-info"></div>
+                    <div id="inventory-info"></div>
+                </div>
+
+                <div class="rpg-card" id="zone-card">
+                    <h2>World Explorer</h2>
+                    <label for="zone-select">Current Zone</label>
+                    <select id="zone-select"></select>
+                    <div id="zone-details" class="info-block"></div>
+                </div>
+            </div>
+
+            <div class="rpg-panel">
+                <div class="rpg-card log-card">
+                    <h2>Adventure Log</h2>
+                    <div id="log" class="log-window" aria-live="polite"></div>
+                </div>
+
+                <div class="rpg-card action-card">
+                    <h2>Actions</h2>
+                    <div class="button-row">
+                        <button id="explore-button" disabled>Explore</button>
+                        <button id="rest-button" disabled>Make Camp</button>
+                    </div>
+
+                    <div id="npc-controls" class="stacked-control hidden">
+                        <label for="npc-select">Speak with</label>
+                        <div class="inline-group">
+                            <select id="npc-select"></select>
+                            <button id="talk-npc-button" disabled>Talk</button>
+                        </div>
+                    </div>
+
+                    <div id="dungeon-controls" class="stacked-control hidden">
+                        <label for="dungeon-select">Dungeons</label>
+                        <div class="inline-group">
+                            <select id="dungeon-select"></select>
+                            <button id="enter-dungeon-button" disabled>Enter Dungeon</button>
+                        </div>
+                    </div>
+
+                    <div id="combat-controls" class="stacked-control hidden">
+                        <label for="ability-select">Combat Ability</label>
+                        <select id="ability-select"></select>
+                        <div id="ability-description" class="info-block"></div>
+                        <button id="use-ability-button">Use Ability</button>
+                        <div id="combat-status"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <footer class="rpg-footnote">Tip: Add new classes, enemies, or entire regions by updating the JSON files—no code changes required.</footer>
+    </section>
+</body>
+</html>

--- a/scripts/rpg-game.js
+++ b/scripts/rpg-game.js
@@ -1,0 +1,962 @@
+(() => {
+  'use strict';
+
+  const DATA_SOURCES = [
+    { key: 'classes', path: 'data/rpg/classes.json' },
+    { key: 'professions', path: 'data/rpg/professions.json' },
+    { key: 'items', path: 'data/rpg/items.json' },
+    { key: 'enemies', path: 'data/rpg/enemies.json' },
+    { key: 'zones', path: 'data/rpg/zones.json' },
+    { key: 'dungeons', path: 'data/rpg/dungeons.json' },
+    { key: 'npcs', path: 'data/rpg/npcs.json' }
+  ];
+
+  const MAX_PROFESSIONS = 2;
+
+  const dom = {};
+  const gameData = { lookups: {} };
+  const state = {
+    loaded: false,
+    started: false,
+    player: null,
+    currentZoneId: null,
+    combat: null,
+    currentDungeon: null,
+    npcRewardsClaimed: new Set()
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    cacheDom();
+    attachEventListeners();
+    loadGameData();
+  });
+
+  function cacheDom() {
+    dom.classSelect = document.getElementById('class-select');
+    dom.classDescription = document.getElementById('class-description');
+    dom.professionOptions = document.getElementById('profession-options');
+    dom.setupFeedback = document.getElementById('setup-feedback');
+    dom.startButton = document.getElementById('start-button');
+    dom.playerNameInput = document.getElementById('player-name');
+    dom.playerInfo = document.getElementById('player-info');
+    dom.inventoryInfo = document.getElementById('inventory-info');
+    dom.zoneSelect = document.getElementById('zone-select');
+    dom.zoneDetails = document.getElementById('zone-details');
+    dom.log = document.getElementById('log');
+    dom.exploreButton = document.getElementById('explore-button');
+    dom.restButton = document.getElementById('rest-button');
+    dom.npcControls = document.getElementById('npc-controls');
+    dom.npcSelect = document.getElementById('npc-select');
+    dom.talkNpcButton = document.getElementById('talk-npc-button');
+    dom.dungeonControls = document.getElementById('dungeon-controls');
+    dom.dungeonSelect = document.getElementById('dungeon-select');
+    dom.enterDungeonButton = document.getElementById('enter-dungeon-button');
+    dom.combatControls = document.getElementById('combat-controls');
+    dom.abilitySelect = document.getElementById('ability-select');
+    dom.abilityDescription = document.getElementById('ability-description');
+    dom.useAbilityButton = document.getElementById('use-ability-button');
+    dom.combatStatus = document.getElementById('combat-status');
+  }
+
+  function attachEventListeners() {
+    dom.classSelect.addEventListener('change', () => updateClassDescription(dom.classSelect.value));
+
+    dom.professionOptions.addEventListener('change', event => {
+      const target = event.target;
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+      if (target.checked) {
+        const selected = getSelectedProfessionIds();
+        if (selected.length > MAX_PROFESSIONS) {
+          target.checked = false;
+          showSetupFeedback(`You can only train ${MAX_PROFESSIONS} professions.`, 'warning');
+        }
+      }
+    });
+
+    dom.startButton.addEventListener('click', startAdventure);
+    dom.zoneSelect.addEventListener('change', () => handleZoneChange(dom.zoneSelect.value));
+    dom.exploreButton.addEventListener('click', exploreCurrentZone);
+    dom.restButton.addEventListener('click', restAtCamp);
+    dom.talkNpcButton.addEventListener('click', talkToSelectedNpc);
+    dom.enterDungeonButton.addEventListener('click', enterOrProgressDungeon);
+    dom.useAbilityButton.addEventListener('click', useSelectedAbility);
+    dom.abilitySelect.addEventListener('change', () => updateAbilityDescription(dom.abilitySelect.value));
+  }
+
+  function loadGameData() {
+    Promise.all(DATA_SOURCES.map(src => fetch(src.path).then(response => {
+      if (!response.ok) {
+        throw new Error(`Failed to load ${src.path}`);
+      }
+      return response.json();
+    })))
+      .then(results => {
+        DATA_SOURCES.forEach((src, index) => {
+          gameData[src.key] = results[index];
+          gameData.lookups[src.key] = Object.fromEntries(results[index].map(entry => [entry.id, entry]));
+        });
+        state.loaded = true;
+        populateInitialUi();
+      })
+      .catch(error => {
+        console.error(error);
+        showSetupFeedback('Failed to load game data. Please refresh.', 'error');
+      });
+  }
+
+  function populateInitialUi() {
+    populateClassOptions();
+    populateProfessionOptions();
+    populateZoneOptions();
+    updateClassDescription(dom.classSelect.value);
+    updateZoneDetails();
+    updateNpcOptions();
+    updateDungeonOptions();
+    updateActionAvailability();
+    addLog('Legends of Azerai awaits. Configure your adventurer to begin.');
+  }
+
+  function populateClassOptions() {
+    clearChildren(dom.classSelect);
+    gameData.classes.forEach((cls, index) => {
+      const option = document.createElement('option');
+      option.value = cls.id;
+      option.textContent = cls.name;
+      if (index === 0) {
+        option.selected = true;
+      }
+      dom.classSelect.append(option);
+    });
+  }
+
+  function populateProfessionOptions() {
+    clearChildren(dom.professionOptions);
+    gameData.professions.forEach(profession => {
+      const label = document.createElement('label');
+      label.className = 'option';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.value = profession.id;
+      const span = document.createElement('span');
+      span.innerHTML = `<strong>${profession.name}</strong><br><small>${profession.description}</small>`;
+      label.append(input, span);
+      dom.professionOptions.append(label);
+    });
+  }
+
+  function populateZoneOptions() {
+    clearChildren(dom.zoneSelect);
+    gameData.zones.forEach((zone, index) => {
+      const option = document.createElement('option');
+      option.value = zone.id;
+      option.textContent = `${zone.name} (Lv. ${zone.recommendedLevel}+ )`;
+      if (index === 0) {
+        option.selected = true;
+        state.currentZoneId = zone.id;
+      }
+      dom.zoneSelect.append(option);
+    });
+  }
+
+  function updateClassDescription(classId) {
+    const cls = gameData.lookups.classes[classId];
+    if (!cls) {
+      dom.classDescription.textContent = 'Select a class to view its lore and abilities.';
+      return;
+    }
+    const abilityList = cls.abilities.map(ability => `<li><strong>${ability.name}</strong> — ${ability.description} (Cost: ${ability.resourceCost} mana)</li>`).join('');
+    dom.classDescription.innerHTML = `
+      <p>${cls.description}</p>
+      <h3>Base Attributes</h3>
+      <ul>
+        <li>Health: ${cls.baseStats.health}</li>
+        <li>Mana: ${cls.baseStats.mana}</li>
+        <li>Strength: ${cls.baseStats.strength}</li>
+        <li>Agility: ${cls.baseStats.agility}</li>
+        <li>Intellect: ${cls.baseStats.intellect}</li>
+      </ul>
+      <h3>Signature Abilities</h3>
+      <ul>${abilityList}</ul>
+    `;
+  }
+
+  function updateZoneDetails() {
+    const zone = getCurrentZone();
+    if (!zone) {
+      dom.zoneDetails.textContent = 'Select a zone to learn more about its dangers and opportunities.';
+      return;
+    }
+
+    const enemies = Array.isArray(zone.enemies) ? zone.enemies : [];
+    const gatherables = Array.isArray(zone.gatherables) ? zone.gatherables : [];
+    const enemyNames = enemies.map(id => gameData.lookups.enemies[id]?.name || id).join(', ');
+    const gatherLines = gatherables.map(node => {
+      const prof = gameData.lookups.professions[node.professionId];
+      const item = gameData.lookups.items[node.itemId];
+      const profName = prof ? prof.name : node.professionId;
+      const itemName = item ? item.name : node.itemId;
+      const quantity = node.minQuantity === node.maxQuantity ? `${node.minQuantity}` : `${node.minQuantity}-${node.maxQuantity}`;
+      return `<li>${itemName} (${quantity}) — ${profName}</li>`;
+    }).join('');
+
+    dom.zoneDetails.innerHTML = `
+      <p><strong>${zone.name}</strong>: ${zone.description}</p>
+      <p><strong>Common Enemies:</strong> ${enemyNames || 'Unknown creatures'}</p>
+      <p><strong>Recommended Level:</strong> ${zone.recommendedLevel}</p>
+      <h3>Resource Nodes</h3>
+      <ul>${gatherLines || '<li>None documented</li>'}</ul>
+    `;
+  }
+
+  function updateNpcOptions() {
+    const zone = getCurrentZone();
+    clearChildren(dom.npcSelect);
+    if (!zone || !zone.npcs || zone.npcs.length === 0) {
+      setHidden(dom.npcControls, true);
+      return;
+    }
+    zone.npcs.forEach((npcId, index) => {
+      const npc = gameData.lookups.npcs[npcId];
+      if (!npc) {
+        return;
+      }
+      const option = document.createElement('option');
+      option.value = npc.id;
+      option.textContent = `${npc.name} — ${npc.role}`;
+      if (index === 0) {
+        option.selected = true;
+      }
+      dom.npcSelect.append(option);
+    });
+    setHidden(dom.npcControls, !state.started);
+  }
+
+  function updateDungeonOptions() {
+    const zone = getCurrentZone();
+    clearChildren(dom.dungeonSelect);
+    if (!zone || !zone.dungeons || zone.dungeons.length === 0) {
+      setHidden(dom.dungeonControls, true);
+      return;
+    }
+    zone.dungeons.forEach((dungeonId, index) => {
+      const dungeon = gameData.lookups.dungeons[dungeonId];
+      if (!dungeon) {
+        return;
+      }
+      const option = document.createElement('option');
+      option.value = dungeon.id;
+      option.textContent = `${dungeon.name} (Lv. ${dungeon.recommendedLevel}+ )`;
+      if (index === 0) {
+        option.selected = true;
+      }
+      dom.dungeonSelect.append(option);
+    });
+    setHidden(dom.dungeonControls, !state.started);
+    updateDungeonButton();
+  }
+
+  function startAdventure() {
+    if (!state.loaded || state.started) {
+      return;
+    }
+    const classId = dom.classSelect.value;
+    const chosenClass = gameData.lookups.classes[classId];
+    if (!chosenClass) {
+      showSetupFeedback('Please select a class to begin.', 'warning');
+      return;
+    }
+    const professions = getSelectedProfessionIds();
+    if (professions.length > MAX_PROFESSIONS) {
+      showSetupFeedback(`Select at most ${MAX_PROFESSIONS} professions.`, 'warning');
+      return;
+    }
+
+    const heroName = dom.playerNameInput.value.trim() || 'Adventurer';
+    state.player = createPlayer(heroName, chosenClass, professions);
+    state.started = true;
+    showSetupFeedback('', 'info');
+    addLog(`${state.player.name}, the ${chosenClass.name}, sets foot in ${getCurrentZone()?.name || 'the wilds'}.`);
+    if (professions.length > 0) {
+      const professionNames = professions.map(id => gameData.lookups.professions[id]?.name || id).join(', ');
+      addLog(`Professions trained: ${professionNames}.`);
+    }
+    updatePlayerInfo();
+    updateInventoryInfo();
+    updateNpcOptions();
+    updateDungeonOptions();
+    updateActionAvailability();
+    updateAbilityChoices();
+  }
+
+  function createPlayer(name, chosenClass, professionIds) {
+    const player = {
+      name,
+      classId: chosenClass.id,
+      className: chosenClass.name,
+      primaryStat: chosenClass.primaryStat,
+      level: 1,
+      xp: 0,
+      attributes: {
+        strength: chosenClass.baseStats.strength,
+        agility: chosenClass.baseStats.agility,
+        intellect: chosenClass.baseStats.intellect
+      },
+      maxHealth: chosenClass.baseStats.health,
+      currentHealth: chosenClass.baseStats.health,
+      maxMana: chosenClass.baseStats.mana,
+      currentMana: chosenClass.baseStats.mana,
+      professions: [...professionIds],
+      inventory: [],
+      abilities: []
+    };
+
+    player.abilities.push(createBasicAbility(chosenClass));
+    chosenClass.abilities.forEach(ability => {
+      player.abilities.push({ ...ability });
+    });
+
+    if (Array.isArray(chosenClass.startingItems)) {
+      chosenClass.startingItems.forEach(itemId => addItemToInventory(player, itemId));
+    }
+
+    return player;
+  }
+
+  function createBasicAbility(chosenClass) {
+    const statLabel = chosenClass.primaryStat.charAt(0).toUpperCase() + chosenClass.primaryStat.slice(1);
+    return {
+      id: 'basic_attack',
+      name: 'Basic Attack',
+      type: 'damage',
+      resourceCost: 0,
+      stat: chosenClass.primaryStat,
+      multiplier: 1.0,
+      flatBonus: 3,
+      description: `A dependable strike fueled by your ${statLabel}.`
+    };
+  }
+
+  function getSelectedProfessionIds() {
+    return Array.from(dom.professionOptions.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
+  }
+
+  function showSetupFeedback(message, level) {
+    dom.setupFeedback.textContent = message;
+    dom.setupFeedback.dataset.level = level || 'info';
+  }
+
+  function updatePlayerInfo() {
+    if (!state.player) {
+      dom.playerInfo.innerHTML = '<p>Create a hero to view statistics.</p>';
+      return;
+    }
+    const player = state.player;
+    const xpGoal = xpToNextLevel(player.level);
+    const professionNames = player.professions.length > 0
+      ? player.professions.map(id => gameData.lookups.professions[id]?.name || id).join(', ')
+      : 'None';
+    dom.playerInfo.innerHTML = `
+      <p><strong>${player.name}</strong> — Level ${player.level} ${player.className}</p>
+      <ul>
+        <li>Health: ${player.currentHealth} / ${player.maxHealth}</li>
+        <li>Mana: ${player.currentMana} / ${player.maxMana}</li>
+        <li>Strength: ${player.attributes.strength}</li>
+        <li>Agility: ${player.attributes.agility}</li>
+        <li>Intellect: ${player.attributes.intellect}</li>
+        <li>Experience: ${player.xp} / ${xpGoal}</li>
+        <li>Professions: ${professionNames}</li>
+      </ul>
+    `;
+  }
+
+  function updateInventoryInfo() {
+    if (!state.player) {
+      dom.inventoryInfo.innerHTML = '';
+      return;
+    }
+    const inventory = state.player.inventory;
+    if (inventory.length === 0) {
+      dom.inventoryInfo.innerHTML = '<h3>Inventory</h3><p>No items carried.</p>';
+      return;
+    }
+    const lines = inventory
+      .slice()
+      .sort((a, b) => {
+        const itemA = gameData.lookups.items[a.itemId]?.name || a.itemId;
+        const itemB = gameData.lookups.items[b.itemId]?.name || b.itemId;
+        return itemA.localeCompare(itemB);
+      })
+      .map(entry => {
+        const item = gameData.lookups.items[entry.itemId];
+        const name = item ? item.name : entry.itemId;
+        return `<li>${name} × ${entry.quantity}</li>`;
+      })
+      .join('');
+    dom.inventoryInfo.innerHTML = `<h3>Inventory</h3><ul>${lines}</ul>`;
+  }
+
+  function handleZoneChange(zoneId) {
+    state.currentZoneId = zoneId;
+    if (state.currentDungeon) {
+      addLog('You abandon your current delve as you travel to a new zone.');
+      state.currentDungeon = null;
+      updateDungeonButton();
+    }
+    updateZoneDetails();
+    updateNpcOptions();
+    updateDungeonOptions();
+    if (state.started) {
+      const zone = getCurrentZone();
+      addLog(`You travel to ${zone ? zone.name : 'an unknown land'}.`);
+    }
+    updateActionAvailability();
+  }
+
+  function exploreCurrentZone() {
+    if (!state.started || state.combat || state.currentDungeon) {
+      return;
+    }
+    const zone = getCurrentZone();
+    if (!zone) {
+      addLog('You look around but find no path forward.');
+      return;
+    }
+    const roll = Math.random();
+    const enemies = Array.isArray(zone.enemies) ? zone.enemies : [];
+    if (roll < 0.6 && enemies.length > 0) {
+      const enemyId = randomChoice(enemies);
+      const enemy = gameData.lookups.enemies[enemyId];
+      if (!enemy) {
+        addLog('An indescribable creature watches from afar.');
+        return;
+      }
+      startCombat(enemy, { source: 'zone', zoneId: zone.id });
+    } else if (roll < 0.85) {
+      resolveGatherEvent(zone);
+    } else {
+      narrateAmbientMoment(zone);
+    }
+  }
+
+  function resolveGatherEvent(zone) {
+    if (!state.player) {
+      return;
+    }
+    const gatherables = Array.isArray(zone.gatherables) ? zone.gatherables : [];
+    const available = gatherables.filter(node => state.player.professions.includes(node.professionId));
+    if (available.length === 0) {
+      addLog('You discover valuable resources but lack the skill to harvest them.');
+      return;
+    }
+    const node = randomChoice(available);
+    const quantity = randomInt(node.minQuantity, node.maxQuantity);
+    addItemToInventory(state.player, node.itemId, quantity);
+    const item = gameData.lookups.items[node.itemId];
+    const itemName = item ? item.name : node.itemId;
+    const profession = gameData.lookups.professions[node.professionId]?.name || node.professionId;
+    addLog(`Your ${profession} training yields ${quantity} × ${itemName}.`);
+    updateInventoryInfo();
+  }
+
+  function narrateAmbientMoment(zone) {
+    if (zone.ambientLore && zone.ambientLore.length > 0) {
+      addLog(randomChoice(zone.ambientLore));
+    } else {
+      addLog('The journey is quiet—for now.');
+    }
+  }
+
+  function restAtCamp() {
+    if (!state.started) {
+      return;
+    }
+    if (state.combat) {
+      addLog('You cannot make camp while fighting!');
+      return;
+    }
+    state.player.currentHealth = state.player.maxHealth;
+    state.player.currentMana = state.player.maxMana;
+    addLog('You make camp and recover your strength.');
+    updatePlayerInfo();
+    updateCombatStatus();
+  }
+
+  function talkToSelectedNpc() {
+    if (!state.started) {
+      return;
+    }
+    const npcId = dom.npcSelect.value;
+    const npc = gameData.lookups.npcs[npcId];
+    if (!npc) {
+      addLog('No ally answers your call.');
+      return;
+    }
+    const line = randomChoice(npc.dialogue);
+    addLog(`${npc.name}: "${line}"`);
+
+    const rewards = Array.isArray(npc.rewards) ? npc.rewards : [];
+    if (rewards.length > 0) {
+      rewards.forEach(reward => {
+        const rewardKey = `${npc.id}:${reward.itemId}`;
+        if (reward.once && state.npcRewardsClaimed.has(rewardKey)) {
+          return;
+        }
+        addItemToInventory(state.player, reward.itemId);
+        const item = gameData.lookups.items[reward.itemId];
+        const itemName = item ? item.name : reward.itemId;
+        addLog(reward.description || `${npc.name} gives you ${itemName}.`);
+        state.npcRewardsClaimed.add(rewardKey);
+      });
+      updateInventoryInfo();
+    }
+
+    const teachings = Array.isArray(npc.teachesProfessions) ? npc.teachesProfessions : [];
+    if (teachings.length > 0) {
+      teachings.forEach(professionId => {
+        if (!state.player.professions.includes(professionId)) {
+          if (state.player.professions.length < MAX_PROFESSIONS) {
+            state.player.professions.push(professionId);
+            const professionName = gameData.lookups.professions[professionId]?.name || professionId;
+            addLog(`${npc.name} teaches you ${professionName}.`);
+          } else {
+            addLog(`${npc.name} offers to teach you more, but you have reached your profession limit.`);
+          }
+        }
+      });
+      updatePlayerInfo();
+      updateZoneDetails();
+    }
+  }
+
+  function enterOrProgressDungeon() {
+    if (!state.started || state.combat) {
+      return;
+    }
+    const selectedId = dom.dungeonSelect.value;
+    if (!selectedId) {
+      addLog('Select a dungeon to enter.');
+      return;
+    }
+    const dungeon = gameData.lookups.dungeons[selectedId];
+    if (!dungeon) {
+      addLog('The path ahead is blocked.');
+      return;
+    }
+
+    if (!state.currentDungeon || state.currentDungeon.id !== selectedId) {
+      state.currentDungeon = {
+        id: selectedId,
+        stage: 'encounters',
+        encounterPointer: 0,
+        readyForNext: false,
+        bossDefeated: false
+      };
+      addLog(`You step into ${dungeon.name}. ${dungeon.description}`);
+      if (state.player.level < dungeon.recommendedLevel) {
+        addLog('A chill runs down your spine—you are below the recommended level.');
+      }
+      startNextDungeonFight();
+    } else if (state.currentDungeon.readyForNext && !state.currentDungeon.bossDefeated) {
+      startNextDungeonFight();
+    } else if (state.currentDungeon.bossDefeated) {
+      addLog('The dungeon lies quiet. You may re-enter after leaving the zone.');
+    } else {
+      addLog('You are already delving this dungeon.');
+    }
+    updateActionAvailability();
+    updateDungeonButton();
+  }
+
+  function startNextDungeonFight() {
+    const dungeonState = state.currentDungeon;
+    if (!dungeonState) {
+      return;
+    }
+    const dungeon = gameData.lookups.dungeons[dungeonState.id];
+    if (!dungeon) {
+      return;
+    }
+
+    if (dungeonState.stage === 'encounters') {
+      const encounters = Array.isArray(dungeon.encounters) ? dungeon.encounters : [];
+      if (dungeonState.encounterPointer < encounters.length) {
+        const enemyId = encounters[dungeonState.encounterPointer];
+        const enemy = gameData.lookups.enemies[enemyId];
+        if (!enemy) {
+          addLog('An unknown threat stalks the halls, but you move on.');
+          dungeonState.encounterPointer += 1;
+          dungeonState.readyForNext = true;
+          updateDungeonButton();
+          return;
+        }
+        dungeonState.readyForNext = false;
+        startCombat(enemy, { source: 'dungeon', dungeonId: dungeon.id, encounterType: 'encounter' });
+      } else {
+        dungeonState.stage = 'boss';
+        dungeonState.readyForNext = true;
+        addLog('You stand before the heart of the dungeon. Steel yourself for the final battle.');
+        updateDungeonButton();
+      }
+    } else if (dungeonState.stage === 'boss') {
+      const boss = gameData.lookups.enemies[dungeon.boss];
+      if (!boss) {
+        addLog('The true foe never appears—the magic here fades away.');
+        finishDungeon();
+        return;
+      }
+      dungeonState.readyForNext = false;
+      startCombat(boss, { source: 'dungeon', dungeonId: dungeon.id, encounterType: 'boss' });
+    }
+  }
+
+  function startCombat(enemy, options) {
+    options = options || {};
+    state.combat = {
+      enemyId: enemy.id,
+      enemyName: enemy.name,
+      maxHealth: enemy.health,
+      health: enemy.health,
+      enemyData: enemy,
+      options
+    };
+    addLog(`A level ${enemy.level} ${enemy.name} challenges you!`);
+    setHidden(dom.combatControls, false);
+    updateAbilityChoices();
+    updateCombatStatus();
+    updateActionAvailability();
+  }
+
+  function useSelectedAbility() {
+    if (!state.combat || !state.player) {
+      addLog('There is nothing to strike at the moment.');
+      return;
+    }
+    const abilityId = dom.abilitySelect.value;
+    const ability = state.player.abilities.find(ab => ab.id === abilityId);
+    if (!ability) {
+      addLog('You hesitate, unsure which technique to use.');
+      return;
+    }
+    if (ability.resourceCost > state.player.currentMana) {
+      addLog('You lack the mana to wield that ability.');
+      return;
+    }
+
+    state.player.currentMana -= ability.resourceCost;
+    const effectiveness = applyVariance(ability.flatBonus + ability.multiplier * (state.player.attributes[ability.stat] || 0));
+
+    if (ability.type === 'heal') {
+      const healAmount = Math.min(effectiveness, state.player.maxHealth - state.player.currentHealth);
+      state.player.currentHealth += healAmount;
+      addLog(`${state.player.name} uses ${ability.name} and restores ${healAmount} health.`);
+    } else {
+      const damage = Math.min(effectiveness, state.combat.health);
+      state.combat.health -= damage;
+      addLog(`${state.player.name} uses ${ability.name}, dealing ${damage} damage.`);
+    }
+
+    updateCombatStatus();
+    updatePlayerInfo();
+
+    if (state.combat.health <= 0) {
+      concludeCombatVictory();
+    } else {
+      enemyTurn();
+    }
+  }
+
+  function enemyTurn() {
+    const enemy = state.combat.enemyData;
+    const damage = randomInt(enemy.damage.min, enemy.damage.max);
+    state.player.currentHealth = Math.max(0, state.player.currentHealth - damage);
+    addLog(`${enemy.name} strikes for ${damage} damage.`);
+    updatePlayerInfo();
+    if (state.player.currentHealth <= 0) {
+      concludeCombatDefeat();
+    } else {
+      updateCombatStatus();
+    }
+  }
+
+  function concludeCombatVictory() {
+    const combat = state.combat;
+    const enemy = combat.enemyData;
+    addLog(`You defeat the ${enemy.name}!`);
+    grantCombatRewards(enemy, combat.options);
+    endCombat();
+    if (combat.options && combat.options.source === 'dungeon') {
+      advanceDungeonState(combat.options);
+    }
+  }
+
+  function concludeCombatDefeat() {
+    const combat = state.combat;
+    const enemy = combat.enemyData;
+    addLog(`The ${enemy.name} overwhelms you. You retreat to safety.`);
+    state.player.currentHealth = Math.max(1, Math.ceil(state.player.maxHealth * 0.5));
+    state.player.currentMana = Math.max(0, Math.ceil(state.player.maxMana * 0.5));
+    if (state.currentDungeon) {
+      addLog('Your delve ends abruptly as you stagger out of the dungeon.');
+      state.currentDungeon = null;
+    }
+    endCombat();
+    updatePlayerInfo();
+    updateActionAvailability();
+  }
+
+  function grantCombatRewards(enemy, options) {
+    const xp = enemy.xp || 0;
+    if (xp > 0) {
+      gainExperience(xp);
+      addLog(`You gain ${xp} experience.`);
+    }
+    if (enemy.loot) {
+      enemy.loot.forEach(entry => {
+        if (Math.random() <= (entry.chance ?? 0)) {
+          addItemToInventory(state.player, entry.itemId, entry.quantity || 1);
+          const itemName = gameData.lookups.items[entry.itemId]?.name || entry.itemId;
+          addLog(`Loot acquired: ${itemName}`);
+        }
+      });
+      updateInventoryInfo();
+    }
+
+    if (options && options.source === 'dungeon' && options.encounterType === 'boss') {
+      rewardDungeonClear(options.dungeonId);
+    }
+  }
+
+  function rewardDungeonClear(dungeonId) {
+    const dungeon = gameData.lookups.dungeons[dungeonId];
+    if (!dungeon) {
+      return;
+    }
+    const rewards = Array.isArray(dungeon.rewards) ? dungeon.rewards : [];
+    if (rewards.length > 0) {
+      rewards.forEach(itemId => {
+        addItemToInventory(state.player, itemId);
+        const itemName = gameData.lookups.items[itemId]?.name || itemId;
+        addLog(`Dungeon reward secured: ${itemName}`);
+      });
+      updateInventoryInfo();
+    }
+  }
+
+  function advanceDungeonState(options) {
+    const dungeonState = state.currentDungeon;
+    if (!dungeonState || dungeonState.id !== options.dungeonId) {
+      return;
+    }
+    const dungeon = gameData.lookups.dungeons[dungeonState.id];
+    if (!dungeon) {
+      return;
+    }
+
+    if (options.encounterType === 'encounter') {
+      const encounters = Array.isArray(dungeon.encounters) ? dungeon.encounters : [];
+      dungeonState.encounterPointer += 1;
+      if (dungeonState.encounterPointer >= encounters.length) {
+        dungeonState.stage = 'boss';
+        addLog('Only the dungeon guardian remains. Prepare when you are ready.');
+      } else {
+        addLog('The path winds deeper. Catch your breath before the next fight.');
+      }
+      dungeonState.readyForNext = true;
+    } else if (options.encounterType === 'boss') {
+      dungeonState.bossDefeated = true;
+      addLog(`You have conquered ${dungeon.name}!`);
+      dungeonState.readyForNext = false;
+      finishDungeon();
+    }
+    updateDungeonButton();
+    updateActionAvailability();
+  }
+
+  function finishDungeon() {
+    state.currentDungeon = null;
+    updateDungeonButton();
+    updateActionAvailability();
+  }
+
+  function endCombat() {
+    state.combat = null;
+    setHidden(dom.combatControls, true);
+    updateActionAvailability();
+  }
+
+  function updateCombatStatus() {
+    if (!state.combat) {
+      dom.combatStatus.textContent = '';
+      return;
+    }
+    const combat = state.combat;
+    const enemy = combat.enemyData;
+    dom.combatStatus.textContent = `${enemy.name} — HP ${combat.health} / ${combat.maxHealth}`;
+  }
+
+  function updateAbilityChoices() {
+    if (!state.player) {
+      clearChildren(dom.abilitySelect);
+      return;
+    }
+    const previousSelection = dom.abilitySelect.value;
+    clearChildren(dom.abilitySelect);
+    state.player.abilities.forEach((ability, index) => {
+      const option = document.createElement('option');
+      option.value = ability.id;
+      option.textContent = `${ability.name} (${ability.type === 'heal' ? 'Heal' : 'Damage'})`;
+      if ((previousSelection && previousSelection === ability.id) || (!previousSelection && index === 0)) {
+        option.selected = true;
+      }
+      dom.abilitySelect.append(option);
+    });
+    updateAbilityDescription(dom.abilitySelect.value);
+  }
+
+  function updateAbilityDescription(abilityId) {
+    if (!state.player) {
+      dom.abilityDescription.textContent = '';
+      return;
+    }
+    const ability = state.player.abilities.find(ab => ab.id === abilityId);
+    if (!ability) {
+      dom.abilityDescription.textContent = '';
+      return;
+    }
+    const costText = ability.resourceCost > 0 ? `${ability.resourceCost} mana` : 'No mana cost';
+    dom.abilityDescription.textContent = `${ability.description} (${costText})`;
+  }
+
+  function updateActionAvailability() {
+    const inCombat = Boolean(state.combat);
+    const inDungeon = Boolean(state.currentDungeon);
+    const gameStarted = Boolean(state.started);
+
+    dom.exploreButton.disabled = !gameStarted || inCombat || inDungeon;
+    dom.restButton.disabled = !gameStarted || inCombat;
+    dom.talkNpcButton.disabled = !gameStarted || inCombat;
+    dom.enterDungeonButton.disabled = !gameStarted || inCombat;
+
+    if (state.started) {
+      updateNpcOptions();
+      updateDungeonOptions();
+    }
+  }
+
+  function updateDungeonButton() {
+    if (setHidden(dom.dungeonControls, !state.started || dom.dungeonSelect.options.length === 0)) {
+      dom.enterDungeonButton.disabled = true;
+      return;
+    }
+    if (!state.currentDungeon) {
+      dom.enterDungeonButton.textContent = 'Enter Dungeon';
+      return;
+    }
+    if (state.currentDungeon.bossDefeated) {
+      dom.enterDungeonButton.textContent = 'Dungeon Cleared';
+      dom.enterDungeonButton.disabled = true;
+      return;
+    }
+    if (state.currentDungeon.stage === 'boss') {
+      dom.enterDungeonButton.textContent = state.currentDungeon.readyForNext ? 'Face the Boss' : 'Battling...';
+    } else {
+      dom.enterDungeonButton.textContent = state.currentDungeon.readyForNext ? 'Continue Deeper' : 'Battling...';
+    }
+  }
+
+  function gainExperience(amount) {
+    state.player.xp += amount;
+    let leveled = false;
+    while (state.player.xp >= xpToNextLevel(state.player.level)) {
+      state.player.xp -= xpToNextLevel(state.player.level);
+      state.player.level += 1;
+      leveled = true;
+      applyLevelGrowth();
+      addLog(`You reach level ${state.player.level}!`);
+    }
+    if (leveled) {
+      updatePlayerInfo();
+    }
+  }
+
+  function applyLevelGrowth() {
+    const chosenClass = gameData.lookups.classes[state.player.classId];
+    if (!chosenClass) {
+      return;
+    }
+    const growth = chosenClass.statGrowth;
+    state.player.maxHealth += growth.health;
+    state.player.maxMana += growth.mana;
+    state.player.attributes.strength += growth.strength;
+    state.player.attributes.agility += growth.agility;
+    state.player.attributes.intellect += growth.intellect;
+    state.player.currentHealth = state.player.maxHealth;
+    state.player.currentMana = state.player.maxMana;
+  }
+
+  function xpToNextLevel(level) {
+    return 100 + (level - 1) * 75;
+  }
+
+  function addItemToInventory(player, itemId, quantity) {
+    quantity = quantity || 1;
+    const existing = player.inventory.find(entry => entry.itemId === itemId);
+    if (existing) {
+      existing.quantity += quantity;
+    } else {
+      player.inventory.push({ itemId, quantity });
+    }
+  }
+
+  function clearChildren(element) {
+    while (element.firstChild) {
+      element.removeChild(element.firstChild);
+    }
+  }
+
+  function setHidden(element, hidden) {
+    if (!element) {
+      return true;
+    }
+    element.classList.toggle('hidden', hidden);
+    return hidden;
+  }
+
+  function randomChoice(array) {
+    if (!array || array.length === 0) {
+      return undefined;
+    }
+    const index = Math.floor(Math.random() * array.length);
+    return array[index];
+  }
+
+  function randomInt(min, max) {
+    const lower = Math.ceil(min);
+    const upper = Math.floor(max);
+    return Math.floor(Math.random() * (upper - lower + 1)) + lower;
+  }
+
+  function applyVariance(value, variance) {
+    const spread = variance ?? 0.2;
+    const factor = 1 - spread + Math.random() * (spread * 2);
+    return Math.max(1, Math.round(value * factor));
+  }
+
+  function getCurrentZone() {
+    if (!state.currentZoneId) {
+      return null;
+    }
+    return gameData.lookups.zones[state.currentZoneId] || null;
+  }
+
+  function addLog(message) {
+    const entry = document.createElement('div');
+    entry.className = 'log-entry';
+    entry.textContent = message;
+    dom.log.append(entry);
+    dom.log.scrollTop = dom.log.scrollHeight;
+  }
+
+})();

--- a/styles.css
+++ b/styles.css
@@ -333,3 +333,212 @@ a:hover {
 a:active {
     color: #f44336;
 }
+
+.hidden {
+    display: none !important;
+}
+
+.rpg-section {
+    max-width: 1200px;
+}
+
+.rpg-section h1 {
+    color: #f0f0f0;
+    text-align: center;
+    margin-bottom: 0.5em;
+}
+
+.rpg-section p.intro {
+    text-align: center;
+    margin-bottom: 1.5em;
+    color: #cccccc;
+}
+
+.rpg-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.rpg-panel {
+    flex: 1 1 340px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.rpg-card {
+    background-color: #171717;
+    border: 1px solid #2d2d2d;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+}
+
+.rpg-card h2 {
+    margin-top: 0;
+    color: #f7f7f7;
+}
+
+.rpg-card h3 {
+    color: #e0e0e0;
+}
+
+.rpg-card ul {
+    padding-left: 20px;
+}
+
+#class-description ul,
+#zone-details ul {
+    margin-top: 0.5em;
+    padding-left: 20px;
+}
+
+#setup-card fieldset {
+    border: 1px solid #2d2d2d;
+    border-radius: 10px;
+    padding: 12px;
+    margin-top: 16px;
+}
+
+#setup-card fieldset legend {
+    padding: 0 8px;
+    color: #f7f7f7;
+}
+
+#profession-options {
+    display: grid;
+    gap: 10px;
+}
+
+#profession-options .option {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    background-color: #1f1f1f;
+    border: 1px solid #303030;
+    border-radius: 8px;
+    padding: 10px;
+}
+
+#profession-options .option input[type="checkbox"] {
+    margin-top: 4px;
+}
+
+.info-block {
+    background-color: #1f1f1f;
+    border: 1px solid #2d2d2d;
+    border-radius: 8px;
+    padding: 10px;
+    margin-top: 10px;
+}
+
+.button-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.button-row button,
+.inline-group button,
+#start-button,
+#use-ability-button {
+    background-color: #2b2b2b;
+    border: 1px solid #444;
+    color: #f7f7f7;
+    border-radius: 6px;
+    padding: 8px 14px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.button-row button:disabled,
+.inline-group button:disabled,
+#start-button:disabled,
+#use-ability-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.button-row button:hover:not(:disabled),
+.inline-group button:hover:not(:disabled),
+#start-button:hover:not(:disabled),
+#use-ability-button:hover:not(:disabled) {
+    background-color: #3a3a3a;
+}
+
+.stacked-control {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.inline-group {
+    display: flex;
+    gap: 8px;
+}
+
+.inline-group select,
+#ability-select,
+#zone-select,
+#class-select,
+#player-name {
+    background-color: #1d1d1d;
+    border: 1px solid #303030;
+    border-radius: 6px;
+    color: #f0f0f0;
+    padding: 8px;
+}
+
+.log-window {
+    background-color: #0f0f0f;
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    padding: 12px;
+    height: 340px;
+    overflow-y: auto;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.log-entry {
+    padding: 4px 0;
+    border-bottom: 1px solid #1f1f1f;
+}
+
+.log-entry:last-child {
+    border-bottom: none;
+}
+
+#combat-status {
+    background-color: #222;
+    border: 1px solid #333;
+    border-radius: 8px;
+    padding: 8px;
+    font-weight: bold;
+    text-align: center;
+}
+
+#setup-feedback[data-level="warning"] {
+    color: #ffb74d;
+}
+
+#setup-feedback[data-level="error"] {
+    color: #ff6f61;
+}
+
+.rpg-footnote {
+    text-align: center;
+    margin-top: 20px;
+    color: #bbbbbb;
+    font-size: 14px;
+}
+
+@media (max-width: 900px) {
+    .rpg-layout {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone `rpg.html` page that hosts the Legends of Azerai text adventure interface and onboarding copy
- implement `scripts/rpg-game.js` to load JSON data, manage combat, professions, NPC interactions, and dungeon flow for the game
- seed the `data/rpg` directory with classes, enemies, items, zones, dungeons, NPCs, and professions JSON to make content extensible
- extend the shared stylesheet with RPG-specific layout, control, and log styling helpers

## Testing
- python scripts/test_json_valid.py

------
https://chatgpt.com/codex/tasks/task_e_68caaa8f41b883208e147ee7dc0347be